### PR TITLE
Updating data files with 2022-2023 data from Google Cloud

### DIFF
--- a/data/regions.csv
+++ b/data/regions.csv
@@ -1,86 +1,162 @@
 region,location,cfe,grid_carbon_intensity,net_operational_ghg_emissions,year
+africa-south1,Johannesburg,0.16,646,0,2023
 asia-east1,Taiwan,0.19,541,0,2019
 asia-east1,Taiwan,0.18,540,0,2020
 asia-east1,Taiwan,0.17,456,0,2021
+asia-east1,Taiwan,0.18,453,0,2022
+asia-east1,Taiwan,0.18,451,0,2023
 asia-east2,Hong Kong,,506,0,2019
 asia-east2,Hong Kong,,453,0,2020
 asia-east2,Hong Kong,0.28,360,0,2021
+asia-east2,Hong Kong,0.28,360,0,2022
+asia-east2,Hong Kong,0.28,360,0,2023
 asia-northeast1,Tokyo,,569,0,2019
 asia-northeast1,Tokyo,0.12,554,0,2020
 asia-northeast1,Tokyo,0.16,464,0,2021
+asia-northeast1,Tokyo,0.16,463,0,2022
+asia-northeast1,Tokyo,0.16,459,0,2023
 asia-northeast2,Osaka,,414,0,2019
 asia-northeast2,Osaka,,442,0,2020
 asia-northeast2,Osaka,0.31,384,0,2021
+asia-northeast2,Osaka,0.32,383,0,2022
+asia-northeast2,Osaka,0.30,385,0,2023
 asia-northeast3,Seoul,,490,0,2019
 asia-northeast3,Seoul,0.31,457,0,2020
 asia-northeast3,Seoul,0.31,425,0,2021
+asia-northeast3,Seoul,0.31,425,0,2022
+asia-northeast3,Seoul,0.35,378,0,2023
 asia-south1,Mumbai,,752,0,2019
 asia-south1,Mumbai,0.12,721,0,2020
 asia-south1,Mumbai,0.23,633,0,2021
+asia-south1,Mumbai,0.24,555,0,2022
+asia-south1,Mumbai,0.14,648,0,2023
 asia-south2,Delhi,,657,0,2020
 asia-south2,Delhi,0.23,633,0,2021
+asia-south2,Delhi,0.23,632,0,2022
+asia-south2,Delhi,0.29,529,0,2023
 asia-southeast1,Singapore,0.03,493,0,2019
 asia-southeast1,Singapore,0.04,493,0,2020
 asia-southeast1,Singapore,0.04,372,0,2021
+asia-southeast1,Singapore,0.04,372,0,2022
+asia-southeast1,Singapore,0.04,369,0,2023
 asia-southeast2,Jakarta,,647,0,2019
 asia-southeast2,Jakarta,,647,0,2020
 asia-southeast2,Jakarta,0.13,580,0,2021
+asia-southeast2,Jakarta,0.13,580,0,2022
+asia-southeast2,Jakarta,0.13,580,0,2023
 australia-southeast1,Sydney,0.11,725,0,2019
 australia-southeast1,Sydney,0.11,727,0,2020
 australia-southeast1,Sydney,0.11,723,0,2021
+australia-southeast1,Sydney,0.27,538,0,2022
+australia-southeast1,Sydney,0.33,501,0,2023
 australia-southeast2,Melbourne,,691,0,2020
 australia-southeast2,Melbourne,0.11,746,0,2021
+australia-southeast2,Melbourne,0.34,490,0,2022
+australia-southeast2,Melbourne,0.40,456,0,2023
 europe-central2,Warsaw,,622,0,2020
 europe-central2,Warsaw,0.2,576,0,2021
+europe-central2,Warsaw,0.24,738,0,2022
+europe-central2,Warsaw,0.31,723,0,2023
 europe-north1,Finland,0.77,181,0,2019
 europe-north1,Finland,0.94,133,0,2020
 europe-north1,Finland,0.91,127,0,2021
+europe-north1,Finland,0.97,112,0,2022
+europe-north1,Finland,0.98,46,0,2023
 europe-southwest1,Madrid,,121,0,2021
+europe-southwest1,Madrid,0.67,160,0,2022
+europe-southwest1,Madrid,0.76,131,0,2023
 europe-west1,Belgium,0.68,196,0,2019
 europe-west1,Belgium,0.79,212,0,2020
 europe-west1,Belgium,0.82,110,0,2021
+europe-west1,Belgium,0.80,123,0,2022
+europe-west1,Belgium,0.82,122,0,2023
 europe-west2,London,0.54,257,0,2019
 europe-west2,London,0.59,231,0,2020
 europe-west2,London,0.57,172,0,2021
+europe-west2,London,0.85,166,0,2022
+europe-west2,London,0.92,136,0,2023
 europe-west3,Frankfurt,0.61,319,0,2019
 europe-west3,Frankfurt,0.63,293,0,2020
 europe-west3,Frankfurt,0.6,269,0,2021
+europe-west3,Frankfurt,0.96,413,0,2022
+europe-west3,Frankfurt,0.90,345,0,2023
 europe-west4,Netherlands,0.61,474,0,2019
 europe-west4,Netherlands,0.6,410,0,2020
 europe-west4,Netherlands,0.53,283,0,2021
+europe-west4,Netherlands,0.57,317,0,2022
+europe-west4,Netherlands,0.80,236,0,2023
 europe-west6,Zurich,,87,0,2019
 europe-west6,Zurich,,87,0,2020
 europe-west6,Zurich,0.85,86,0,2021
+europe-west6,Zurich,0.85,118,0,2022
+europe-west6,Zurich,0.92,59,0,2023
 europe-west8,Milan,,298,0,2021
+europe-west8,Milan,0.42,323,0,2022
+europe-west8,Milan,0.52,249,0,2023
 europe-west9,Paris,,59,0,2021
+europe-west9,Paris,0.87,71,0,2022
+europe-west9,Paris,0.94,34,0,2023
+europe-west10,Berlin,0.90,345,0,2023
+europe-west12,Turin,0.42,323,0,2022
+europe-west12,Turin,0.52,249,0,2023
+me-central1,Doha,0.00,575,0,2023
+me-central2,Dammam,0.00,569,0,2023
+me-west1,Tel Aviv,0.02,0,476,2022
+me-west1,Tel Aviv,0.05,463,0,2023
 northamerica-northeast1,Montreal,,27,0,2019
 northamerica-northeast1,Montréal,,27,0,2020
 northamerica-northeast1,Montréal,0.95,142,0,2021
+northamerica-northeast1,Montréal,1.00,0,0,2022
+northamerica-northeast1,Montréal,1.00,0,0,2023
 northamerica-northeast2,Toronto,0.86,142,0,2021
+northamerica-northeast2,Toronto,0.90,36,0,2022
+northamerica-northeast2,Toronto,0.87,47,0,2023
 southamerica-east1,Sao Paulo,0.87,109,0,2019
 southamerica-east1,São Paulo,0.88,103,0,2020
 southamerica-east1,São Paulo,0.78,129,0,2021
+southamerica-east1,São Paulo,0.89,65,0,2022
+southamerica-east1,São Paulo,0.90,56,0,2023
 southamerica-west1,Santiago,0.69,190,0,2021
+southamerica-west1,Santiago,0.90,165,0,2022
+southamerica-west1,Santiago,0.91,138,0,2023
 us-central1,Iowa,0.78,479,0,2019
 us-central1,Iowa,0.93,454,0,2020
 us-central1,Iowa,0.97,394,0,2021
+us-central1,Iowa,0.92,445,0,2022
+us-central1,Iowa,0.95,430,0,2023
 us-east1,South Carolina,0.19,500,0,2019
 us-east1,South Carolina,0.27,480,0,2020
 us-east1,South Carolina,0.25,434,0,2021
+us-east1,South Carolina,0.26,532,0,2022
+us-east1,South Carolina,0.29,560,0,2023
 us-east4,Northern Virginia,0.41,383,0,2019
 us-east4,Northern Virginia,0.58,361,0,2020
 us-east4,Northern Virginia,0.64,309,0,2021
+us-east4,Northern Virginia,0.60,354,0,2022
+us-east4,Northern Virginia,0.52,322,0,2023
 us-east5,Columbus,0.64,309,0,2021
-us-south1,Dallas,0.4,296,0,2021
+us-east5,Columbus,0.60,354,0,2022
+us-east5,Columbus,0.52,322,0,2023
+us-south1,Dallas,0.40,296,0,2021
+us-south1,Dallas,0.41,342,0,2022
+us-south1,Dallas,0.79,321,0,2023
 us-west1,Oregon,0.89,117,0,2019
 us-west1,Oregon,0.9,78,0,2020
 us-west1,Oregon,0.88,60,0,2021
+us-west1,Oregon,0.89,67,0,2022
+us-west1,Oregon,0.84,94,0,2023
 us-west2,Los Angeles,0.55,248,0,2019
 us-west2,Los Angeles,0.54,253,0,2020
 us-west2,Los Angeles,0.53,190,0,2021
+us-west2,Los Angeles,0.56,202,0,2022
+us-west2,Los Angeles,0.55,198,0,2023
 us-west3,Salt Lake City,0.25,561,0,2019
 us-west3,Salt Lake City,0.28,533,0,2020
 us-west3,Salt Lake City,0.31,448,0,2021
+us-west3,Salt Lake City,0.31,606,0,2022
+us-west3,Salt Lake City,0.29,588,0,2023
 us-west4,Las Vegas,0.13,491,0,2019
 us-west4,Las Vegas,0.19,455,0,2020
 us-west4,Las Vegas,0.21,365,0,2021
+us-west4,Las Vegas,0.21,396,0,2022
+us-west4,Las Vegas,0.26,373B,0,2023

--- a/data/regions.json
+++ b/data/regions.json
@@ -1,4 +1,16 @@
 {
+    "africa-south1": {
+        "name": "asia-south1",
+        "location": "Johannesburg",
+        "summary": [
+            {
+                "cfe": "0.16",
+                "grid_carbon_intensity": "646",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
+            }
+        ]
+    },
     "asia-east1": {
         "name": "asia-east1",
         "location": "Taiwan",
@@ -20,6 +32,18 @@
                 "grid_carbon_intensity": "456",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.18",
+                "grid_carbon_intensity": "453",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.17",
+                "grid_carbon_intensity": "456",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -44,6 +68,18 @@
                 "grid_carbon_intensity": "360",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.28",
+                "grid_carbon_intensity": "360",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.28",
+                "grid_carbon_intensity": "360",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -68,6 +104,18 @@
                 "grid_carbon_intensity": "464",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.16",
+                "grid_carbon_intensity": "463",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.16",
+                "grid_carbon_intensity": "459",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -92,6 +140,18 @@
                 "grid_carbon_intensity": "384",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.32",
+                "grid_carbon_intensity": "383",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.30",
+                "grid_carbon_intensity": "385",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -116,6 +176,18 @@
                 "grid_carbon_intensity": "425",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.31",
+                "grid_carbon_intensity": "425",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.35",
+                "grid_carbon_intensity": "378",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -140,6 +212,18 @@
                 "grid_carbon_intensity": "633",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.24",
+                "grid_carbon_intensity": "555",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.14",
+                "grid_carbon_intensity": "648",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -158,6 +242,18 @@
                 "grid_carbon_intensity": "633",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.23",
+                "grid_carbon_intensity": "632",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.29",
+                "grid_carbon_intensity": "529",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -182,6 +278,18 @@
                 "grid_carbon_intensity": "372",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.04",
+                "grid_carbon_intensity": "372",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.04",
+                "grid_carbon_intensity": "369",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -206,6 +314,18 @@
                 "grid_carbon_intensity": "580",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.13",
+                "grid_carbon_intensity": "580",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.13",
+                "grid_carbon_intensity": "580",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -230,6 +350,18 @@
                 "grid_carbon_intensity": "723",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.27",
+                "grid_carbon_intensity": "538",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.33",
+                "grid_carbon_intensity": "501",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -248,6 +380,18 @@
                 "grid_carbon_intensity": "746",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.34",
+                "grid_carbon_intensity": "490",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.40",
+                "grid_carbon_intensity": "456",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -266,6 +410,18 @@
                 "grid_carbon_intensity": "576",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.24",
+                "grid_carbon_intensity": "738",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.31",
+                "grid_carbon_intensity": "723",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -290,6 +446,18 @@
                 "grid_carbon_intensity": "127",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.97",
+                "grid_carbon_intensity": "112",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.98",
+                "grid_carbon_intensity": "46",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -302,6 +470,18 @@
                 "grid_carbon_intensity": "121",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.67",
+                "grid_carbon_intensity": "160",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.76",
+                "grid_carbon_intensity": "131",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -326,6 +506,18 @@
                 "grid_carbon_intensity": "110",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.80",
+                "grid_carbon_intensity": "123",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.82",
+                "grid_carbon_intensity": "122",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -350,6 +542,18 @@
                 "grid_carbon_intensity": "172",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.85",
+                "grid_carbon_intensity": "166",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.92",
+                "grid_carbon_intensity": "136",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -374,6 +578,18 @@
                 "grid_carbon_intensity": "269",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.96",
+                "grid_carbon_intensity": "413",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.90",
+                "grid_carbon_intensity": "345",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -398,6 +614,18 @@
                 "grid_carbon_intensity": "283",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.57",
+                "grid_carbon_intensity": "317",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.80",
+                "grid_carbon_intensity": "236",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -422,6 +650,18 @@
                 "grid_carbon_intensity": "86",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.85",
+                "grid_carbon_intensity": "118",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.92",
+                "grid_carbon_intensity": "59",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -434,6 +674,18 @@
                 "grid_carbon_intensity": "298",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.42",
+                "grid_carbon_intensity": "323",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.52",
+                "grid_carbon_intensity": "249",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -446,6 +698,90 @@
                 "grid_carbon_intensity": "59",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.87",
+                "grid_carbon_intensity": "71",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.94",
+                "grid_carbon_intensity": "34",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
+            }
+        ]
+    },
+    "europe-west10": {
+        "name": "europe-west10",
+        "location": "Berlin",
+        "summary": [
+            {
+                "cfe": "0.90",
+                "grid_carbon_intensity": "345",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
+            }
+        ]
+    },
+    "europe-west12": {
+        "name": "europe-west12",
+        "location": "Turin",
+        "summary": [
+            {
+                "cfe": "0.42",
+                "grid_carbon_intensity": "323",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.52",
+                "grid_carbon_intensity": "249",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
+            }
+        ]
+    },
+    "me-central1": {
+        "name": "me-central1",
+        "location": "Doha",
+        "summary": [
+            {
+                "cfe": "0.0",
+                "grid_carbon_intensity": "575",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
+            }
+        ]
+    },
+    "me-central2": {
+        "name": "me-central2",
+        "location": "Dammam",
+        "summary": [
+            {
+                "cfe": "0.0",
+                "grid_carbon_intensity": "569",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
+            }
+        ]
+    },
+    "me-west1": {
+        "name": "me-west1",
+        "location": "Tel Aviv",
+        "summary": [
+            {
+                "cfe": "0.02",
+                "grid_carbon_intensity": "476",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.05",
+                "grid_carbon_intensity": "463",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -470,6 +806,18 @@
                 "grid_carbon_intensity": "142",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "1.00",
+                "grid_carbon_intensity": "0",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "1.0",
+                "grid_carbon_intensity": "2",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -482,6 +830,18 @@
                 "grid_carbon_intensity": "142",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.90",
+                "grid_carbon_intensity": "36",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.87",
+                "grid_carbon_intensity": "47",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -506,6 +866,18 @@
                 "grid_carbon_intensity": "129",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.89",
+                "grid_carbon_intensity": "65",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.90",
+                "grid_carbon_intensity": "56",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -518,6 +890,18 @@
                 "grid_carbon_intensity": "190",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.90",
+                "grid_carbon_intensity": "165",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.91",
+                "grid_carbon_intensity": "138",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -542,6 +926,18 @@
                 "grid_carbon_intensity": "394",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.92",
+                "grid_carbon_intensity": "445",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.95",
+                "grid_carbon_intensity": "430",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -566,6 +962,18 @@
                 "grid_carbon_intensity": "434",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.26",
+                "grid_carbon_intensity": "532",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.29",
+                "grid_carbon_intensity": "560",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -590,6 +998,18 @@
                 "grid_carbon_intensity": "309",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.60",
+                "grid_carbon_intensity": "354",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.52",
+                "grid_carbon_intensity": "322",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -602,6 +1022,18 @@
                 "grid_carbon_intensity": "309",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.60",
+                "grid_carbon_intensity": "354",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.52",
+                "grid_carbon_intensity": "322",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -610,10 +1042,22 @@
         "location": "Dallas",
         "summary": [
             {
-                "cfe": "0.4",
+                "cfe": "0.40",
                 "grid_carbon_intensity": "296",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.41",
+                "grid_carbon_intensity": "342",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.79",
+                "grid_carbon_intensity": "321",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -638,6 +1082,18 @@
                 "grid_carbon_intensity": "60",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.89",
+                "grid_carbon_intensity": "67",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.84",
+                "grid_carbon_intensity": "94",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -662,6 +1118,18 @@
                 "grid_carbon_intensity": "190",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.56",
+                "grid_carbon_intensity": "202",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.55",
+                "grid_carbon_intensity": "198",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -686,6 +1154,18 @@
                 "grid_carbon_intensity": "448",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.31",
+                "grid_carbon_intensity": "606",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.29",
+                "grid_carbon_intensity": "588",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     },
@@ -710,6 +1190,18 @@
                 "grid_carbon_intensity": "365",
                 "net_operational_ghg_emissions": "0",
                 "year": "2021"
+            },
+            {
+                "cfe": "0.027",
+                "grid_carbon_intensity": "396",
+                "net_operational_ghg_emissions": "0",
+                "year": "2022"
+            },
+            {
+                "cfe": "0.26",
+                "grid_carbon_intensity": "373",
+                "net_operational_ghg_emissions": "0",
+                "year": "2023"
             }
         ]
     }


### PR DESCRIPTION
An update of the data files powering the plugin, incorporating all updated data for 2022-2023 (including any new regions) directly from the Google Cloud carbon repo: https://github.com/GoogleCloudPlatform/region-carbon-info