### PR TITLE
re: #4, Fixing site environment command to be compatible with Terminus 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "phpunit/phpunit": "^9",
     "symfony/yaml": "^5",
     "squizlabs/php_codesniffer": "^3.6",
-    "pantheon-systems/terminus": "^2 || ^3"
+    "pantheon-systems/terminus": "^2 || ^3 || ^4"
   },
   "extra": {
     "terminus": {
-      "compatible-version": "^2 || ^3"
+      "compatible-version": "^2 || ^3 || ^4"
     }
   },
   "scripts": {

--- a/src/Commands/Carbon/SiteEnvRegionCommand.php
+++ b/src/Commands/Carbon/SiteEnvRegionCommand.php
@@ -63,7 +63,9 @@ class SiteEnvRegionCommand extends TerminusCommand implements SiteAwareInterface
         $this->requireSiteIsNotFrozen($site_env);
 
         $env = $this->getEnv($site_env);
-        $site = $this->getSite($site_env);
+
+	$site_name = explode(".",$site_env);	
+	$site = $this->getSiteById($site_name[0]);
 
         $region = new Regions();
         $site_data = $region->mergeRegionData($site);

--- a/src/Commands/Carbon/SiteEnvRegionCommand.php
+++ b/src/Commands/Carbon/SiteEnvRegionCommand.php
@@ -64,8 +64,7 @@ class SiteEnvRegionCommand extends TerminusCommand implements SiteAwareInterface
 
         $env = $this->getEnv($site_env);
 
-        $site_name = explode(".",$site_env);	
-        $site = $this->getSiteById($site_name[0]);
+        $site = $this->getSiteById($site_env);
 
         $region = new Regions();
         $site_data = $region->mergeRegionData($site);

--- a/src/Commands/Carbon/SiteEnvRegionCommand.php
+++ b/src/Commands/Carbon/SiteEnvRegionCommand.php
@@ -64,8 +64,8 @@ class SiteEnvRegionCommand extends TerminusCommand implements SiteAwareInterface
 
         $env = $this->getEnv($site_env);
 
-	$site_name = explode(".",$site_env);	
-	$site = $this->getSiteById($site_name[0]);
+        $site_name = explode(".",$site_env);	
+        $site = $this->getSiteById($site_name[0]);
 
         $region = new Regions();
         $site_data = $region->mergeRegionData($site);


### PR DESCRIPTION
Updating SiteEnvCommand with updated code per internal discussion.

---

Recreated from #6 (fork PR by @schnippy) to satisfy the org's signed-commit requirement. This branch contains @schnippy's three original commits — authored by him (with @ryanshoover's co-authored suggestion preserved) and re-signed by me — rebased onto the current `main`.

Net change vs `main`: `SiteEnvRegionCommand.php` now uses `getSiteById()` per @ryanshoover's review, and `composer.json` adds `^4` to the Terminus version and compatible-version constraints.

Original PR: #6